### PR TITLE
feat: Send metrics via its own threads for real-time data

### DIFF
--- a/autopilot/Lab_2/video_feed.py
+++ b/autopilot/Lab_2/video_feed.py
@@ -1,0 +1,33 @@
+from flask import Flask, Response
+import cv2
+
+app = Flask(__name__)
+
+
+def generate_frames():
+    camera = cv2.VideoCapture(0)  # Use the appropriate camera index
+    if not camera.isOpened():
+        print("Cannot open camera")
+        exit()
+    while True:
+        success, frame = camera.read()
+        if not success:
+            break
+        else:
+            ret, buffer = cv2.imencode('.jpg', frame)
+            frame = buffer.tobytes()
+            # give out frame using generator
+            yield (b'--frame\r\n'
+                   b'Content-Type: image/jpeg\r\n\r\n' + frame + b'\r\n')
+
+
+@app.route('/video_feed')
+def video_feed():
+    # use multipart/x-mixed-replace to tell client that content will be replaced with new content (i.e. next frame)
+    # simulates smooth video playback
+    return Response(generate_frames(),
+                    mimetype='multipart/x-mixed-replace; boundary=frame')
+
+
+def start_video_feed():
+    app.run(host="0.0.0.0", port=5000)  # make it accessible on IP address of pi

--- a/autopilot/Lab_2/wifi_server.py
+++ b/autopilot/Lab_2/wifi_server.py
@@ -1,104 +1,66 @@
 import socket
 import picar_4wd as fc
 import threading
-import subprocess
-import json
-#from picamera import PiCamera
 import time
-import io
-import struct
-import numpy as np
-import cv2 as cv
+import json
 
-def get_local_ip_address():
-    try:
-        ip_address = subprocess.check_output(["hostname", "-I"]).decode("utf-8").split()[0]
-        return ip_address
-    except subprocess.CalledProcessError:
-        print("Error retrieving IP address.")
-        return None
-    
-HOST = get_local_ip_address() or "192.168.0.15" # IP address of your Raspberry PI
-PORT = 65432          # Port to listen on (non-privileged ports are > 1023)
-POWER = 10            # Power of motors
+HOST = "192.168.0.14"  # IP address of your Raspberry PI
+PORT = 65432           # Port to listen on (non-privileged ports are > 1023)
+POWER = 10             # Power of motors
 
-'''
-Send metrics sends
-car's battery state,
-current speed, and cpu temp
-to the client
-'''
+
 def get_metrics():
-    print("sending metrics...")
-    metrics = {}
-    # get battery state
-    metrics['battery'] = fc.power_read()
-    # get speed
-    metrics['speed'] = fc.speed_val()
-    # get cpu temp
-    metrics['cpu_temp'] = fc.cpu_temperature()
+    metrics = {
+        'battery': fc.power_read(),
+        'speed': fc.speed_val(),
+        'cpu_temp': fc.cpu_temperature()
+    }
     return metrics
 
 
 def handle_client(client, client_info):
+    # continuously send metrics e.g. battery, speed, cpu temperature
+    def send_data():
+        while True:
+            metrics = get_metrics()
+            data_message = json.dumps(metrics)
+            try:
+                client.sendall(data_message.encode('utf-8'))
+            except:
+                break  # exit loop if error
+            time.sleep(1)
+
+    # send data continuously in separate thread
+    data_thread = threading.Thread(target=send_data)
+    data_thread.start()
+
     try:
-        command = client.recv(1024).decode('utf-8').strip()
-        if command == "start_camera":
-            threading.Thread(target=send_camera_feed, args=(client, client_info)).start()
-        else:
-            while True:
-                if not command:
-                    break
-                print(f"Received command from {client_info}: {command}")
-                if command == "start_forward":
-                    # Start moving forward
-                    fc.forward(POWER)
-                elif command == "start_reverse":
-                    fc.backward(POWER)
-                elif command == "start_left":
-                    fc.turn_left(POWER)
-                elif command == "start_right":
-                    fc.turn_right(POWER)
-                elif command == "stop_car":
-                    # Stop moving forward
-                    fc.stop()
-                    break
-                elif command == "get_metrics":
-                    metrics = get_metrics()
-                    client.sendall(json.dumps(metrics).encode())
-                    break
-                else:
-                    print("Invalid command received: ", command)
-                    break
+        while True:
+            data = client.recv(1024)  # receive 1024 Bytes of message in binary format
+            if not data:
+                break
+            command = data.decode('utf-8').strip()
+            print(f"Received command from {client_info}: {command}")
+            if command == "start_forward":
+                # Start moving forward
+                fc.forward(POWER)
+            elif command == "start_reverse":
+                fc.backward(POWER)
+            elif command == "start_left":
+                fc.turn_left(POWER)
+            elif command == "start_right":
+                fc.turn_right(POWER)
+            elif command == "stop_car":
+                # Stop moving forward
+                fc.stop()
+            else:
+                print("Invalid command received: ", command)
     except Exception as e:
         print(f"Error handling client {client_info}: {e}")
     finally:
         client.close()
+        data_thread.join()  # stop data sending thread
 
-def send_camera_feed(client, client_info):
-    try:
-        # Create a stream for the camera to capture frames
-        cap = cv.VideoCapture(0)
-        if not cap.isOpened():
-            print("Cannot open camera")
-            exit()
-
-        while True:
-            ret, frame = cap.read()
-            if not ret:
-                print("Cannot receive frame. Exiting...")
-                break
-            
-            # Send the size of the data followed by the data itself
-            size = len(frame)
-            client.sendall(struct.pack('<L', size) + frame)
-
-            time.sleep(0.1)  # Adjust the interval based on your needs
-
-    except Exception as e:
-        print(f"Error sending camera feed to {client_info}: {e}")
-    finally:
-        client.close()
 
 with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
     s.bind((HOST, PORT))
@@ -108,14 +70,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         while True:
             client, client_info = s.accept()
             print(f"Connection from {client_info}")
-            # Receive the message from the client
-            # message = client.recv(1024).decode('utf-8').strip()
-
-            # if message == "get_metrics":
-            #     threading.Thread(target=send_metrics, args=(client, client_info)).start()
-            # else:
             threading.Thread(target=handle_client, args=(client, client_info)).start()
-            threading.Thread(target=send_camera_feed, args=(client, client_info)).start()
     except KeyboardInterrupt:
         # Handle Ctrl+C for a graceful shutdown
         print("Server shutting down.")
@@ -124,6 +79,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         print(f"Exception: {e}")
     finally:
         s.close()
+
 
 ############## unused #################
 #

--- a/autopilot/Lab_2/wifi_server.py
+++ b/autopilot/Lab_2/wifi_server.py
@@ -77,6 +77,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
     s.bind((HOST, PORT))
     s.listen()
     print(f"Server listening on {HOST}:{PORT}")
+    fc.start_speed_thread()  # start separate thread to calculate vehicle speed
     try:
         while True:
             client, client_info = s.accept()

--- a/autopilot/Lab_2/wifi_server.py
+++ b/autopilot/Lab_2/wifi_server.py
@@ -3,8 +3,19 @@ import picar_4wd as fc
 import threading
 import time
 import json
+import subprocess
 
-HOST = "192.168.0.14"  # IP address of your Raspberry PI
+
+def get_local_ip_address():
+    try:
+        ip_address = subprocess.check_output(["hostname", "-I"]).decode("utf-8").split()[0]
+        return ip_address
+    except subprocess.CalledProcessError:
+        print("Error retrieving IP address.")
+        return None
+
+
+HOST = get_local_ip_address() or "192.168.0.14"  # IP address of your Raspberry PI
 PORT = 65432           # Port to listen on (non-privileged ports are > 1023)
 POWER = 10             # Power of motors
 

--- a/autopilot/Lab_2/wifi_server.py
+++ b/autopilot/Lab_2/wifi_server.py
@@ -4,6 +4,7 @@ import threading
 import time
 import json
 import subprocess
+from video_feed import start_video_feed
 
 
 def get_local_ip_address():
@@ -19,7 +20,14 @@ HOST = get_local_ip_address() or "192.168.0.14"  # IP address of your Raspberry 
 PORT = 65432           # Port to listen on (non-privileged ports are > 1023)
 POWER = 10             # Power of motors
 
+# ------------------------------- flask server for video feed ---------------------------------
 
+# start flask app in separate thread for video feed
+video_feed_thread = threading.Thread(target=start_video_feed)
+video_feed_thread.start()
+
+
+# ---------------------------------------- socket server ---------------------------------------
 def get_metrics():
     metrics = {
         'battery': fc.power_read(),
@@ -77,7 +85,7 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
     s.bind((HOST, PORT))
     s.listen()
     print(f"Server listening on {HOST}:{PORT}")
-    fc.start_speed_thread()  # start separate thread to calculate vehicle speed
+    fc.start_speed_thread()  # separate thread to calculate vehicle speed
     try:
         while True:
             client, client_info = s.accept()
@@ -91,24 +99,3 @@ with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         print(f"Exception: {e}")
     finally:
         s.close()
-
-
-############## unused #################
-#
-# with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
-#     s.bind((HOST, PORT))
-#     s.listen()
-#     client, clientInfo = s.accept()
-#     try:
-#         while 1:
-#             client, clientInfo = s.accept()
-#             print("server recv from: ", clientInfo)
-#             data = client.recv(1024)      # receive 1024 Bytes of message in binary format
-#             if data != b"":
-#                 # match action
-#                 print(data)
-#                 client.sendall(data) # Echo back to client
-#     except:
-#         print("Closing socket")
-#         client.close()
-#         s.close()


### PR DESCRIPTION
use a separate thread to send metrics in real time. This also reduces network traffic and avoids synchronization issues (e.g. get_metrics and drive commands simultaneously)